### PR TITLE
Add Electron config file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ firstPRMergeComment: >
 
 You can opt out of having the bot comment on first time pull requests, pull request merges, or new issues by not filling in a value for each app's respective field.
 
-For some examples of content that other people included in their `.github/config` files, check out [Electron's Config File](https://github.com/electron/electron/blob/master/.github/config.yml)
+For some inspiration about what kind of content to included in your `.github/config` files, check out [Electron's Config File](https://github.com/electron/electron/blob/master/.github/config.yml).

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ firstPRMergeComment: >
 
 You can opt out of having the bot comment on first time pull requests, pull request merges, or new issues by not filling in a value for each app's respective field.
 
-For some inspiration about what kind of content to included in your `.github/config` files, check out [Electron's Config File](https://github.com/electron/electron/blob/master/.github/config.yml).
+For some inspiration about what kind of content to include in your `.github/config` files, check out [Electron's Configuration](https://github.com/electron/electron/blob/master/.github/config.yml).

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ firstPRMergeComment: >
 ```
 
 You can opt out of having the bot comment on first time pull requests, pull request merges, or new issues by not filling in a value for each app's respective field.
+
+For some examples of content that other people included in their `.github/config` files, check out [Electron's Config File](https://github.com/electron/electron/blob/master/.github/config.yml)


### PR DESCRIPTION
Eventually, I'd love to include several links to open source repos that have installed the bot as examples/inspiration.